### PR TITLE
adds preload prop (refactors CardImage props), enables on index and projects pages

### DIFF
--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -7,6 +7,12 @@ import { Project } from '../util/';
 interface ProjectCardProps {
   project: Project
   vertical?: boolean
+  preload?: boolean
+}
+
+interface ProjectCardImageProps {
+  project: Project
+  preload: boolean
 }
 
 const linkProps = {
@@ -14,7 +20,7 @@ const linkProps = {
   target: '_blank',
 };
 
-function ProjectCardImage(project: Project) {
+function ProjectCardImage({project, preload}: ProjectCardImageProps) {
   const { image, alt, link } = project;
   return (
     <Link href={link}>
@@ -25,15 +31,14 @@ function ProjectCardImage(project: Project) {
           width="1000"
           height="800"
           layout="responsive"
+          priority={preload}
         />
       </a>
     </Link>
   );
 }
 
-function ProjectCardBody(project: Project) {
-  const { name, description, repo, link, lang, tech } = project;
-  // TODO - link props on anchor, waiting on westwoodcss change
+function ProjectCardBody({ name, description, repo, link, lang, tech }: Project) {
   return (
     <div className="card-body">
       <h3 className="mt-1">
@@ -56,11 +61,12 @@ function ProjectCardBody(project: Project) {
 }
 
 // TODO(mattxwang): consider revisiting how this component works
-function ProjectCard({project, vertical = false}: ProjectCardProps): JSX.Element {
+// TODO(mattxwang): Mobile responsiveness (waiting on WestwoodCSS)
+function ProjectCard({project, vertical = false, preload = false}: ProjectCardProps): JSX.Element {
   if (vertical) {
     return (
       <div className="card">
-        <ProjectCardImage {...project}/>
+        <ProjectCardImage project={project} preload={preload}/>
         <ProjectCardBody {...project}/>
       </div>
     );
@@ -69,7 +75,7 @@ function ProjectCard({project, vertical = false}: ProjectCardProps): JSX.Element
     <div className="card">
       <div className="row">
         <div className="col-6">
-          <ProjectCardImage {...project}/>
+          <ProjectCardImage project={project} preload={preload}/>
         </div>
         <div className="col-6">
           <ProjectCardBody {...project}/>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -90,7 +90,7 @@ export default function Home({
         <hr className="mt-2" />
 
         <h2>featured project</h2>
-        <ProjectCard project={projects[0]} />
+        <ProjectCard project={projects[0]} preload={true} />
         <h2>what we&apos;ve been doing recently...</h2>
         <p>repositories: {numRepos}</p>
         <div className="card">

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -16,10 +16,10 @@ function Projects(): JSX.Element {
         </p>
         <hr />
         <div className="row">
-          {projects.map((project) => {
+          {projects.map((project, i) => {
             return (
               <div className="col-4" key={project.name}>
-                <ProjectCard project={project} vertical />
+                <ProjectCard project={project} vertical preload={i < 3} />
               </div>
             );
           })}

--- a/test/pages/__snapshots__/index.test.tsx.snap
+++ b/test/pages/__snapshots__/index.test.tsx.snap
@@ -190,11 +190,12 @@ exports[`Home page matches snapshot 1`] = `
                 <div
                   style="display: block; box-sizing: border-box; padding-top: 80%;"
                 />
-                <noscript />
                 <img
                   alt="buffer buffet landing splash"
                   decoding="async"
-                  src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                  sizes="100vw"
+                  src="/_next/image?url=%2Fprojects%2Fbuffer-buffet.png&w=3840&q=75"
+                  srcset="/_next/image?url=%2Fprojects%2Fbuffer-buffet.png&w=640&q=75 640w, /_next/image?url=%2Fprojects%2Fbuffer-buffet.png&w=750&q=75 750w, /_next/image?url=%2Fprojects%2Fbuffer-buffet.png&w=828&q=75 828w, /_next/image?url=%2Fprojects%2Fbuffer-buffet.png&w=1080&q=75 1080w, /_next/image?url=%2Fprojects%2Fbuffer-buffet.png&w=1200&q=75 1200w, /_next/image?url=%2Fprojects%2Fbuffer-buffet.png&w=1920&q=75 1920w, /_next/image?url=%2Fprojects%2Fbuffer-buffet.png&w=2048&q=75 2048w, /_next/image?url=%2Fprojects%2Fbuffer-buffet.png&w=3840&q=75 3840w"
                   style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
                 />
               </div>


### PR DESCRIPTION
By default, Next lazy-loads all images; this PR lets us manually toggle that through the `ProjectCard` component, and then applies that on components we deem that are going to be above the fold.