### PR TITLE
Adds logic to `CreateEvent` and `DeleteEvent` for repository creation/deletion

### DIFF
--- a/components/GitHubEventAction.tsx
+++ b/components/GitHubEventAction.tsx
@@ -12,11 +12,11 @@ interface GitHubEventActionProps {
 function GitHubEventAction({type, payload}: GitHubEventActionProps): JSX.Element {
   const unknown = <span>did a {type} on</span>;
   switch(type){
-    case 'CreateEvent': 
+    case 'CreateEvent':
     case 'DeleteEvent': {
       const target = payload?.ref;
       const targetType = payload?.ref_type;
-      const action = type === 'CreateEvent'? 'created' : 'deleted'; 
+      const action = type === 'CreateEvent'? 'created' : 'deleted';
       if (!target) {
         return <span>{action} the {targetType} </span>;
       }

--- a/components/GitHubEventAction.tsx
+++ b/components/GitHubEventAction.tsx
@@ -12,14 +12,17 @@ interface GitHubEventActionProps {
 function GitHubEventAction({type, payload}: GitHubEventActionProps): JSX.Element {
   const unknown = <span>did a {type} on</span>;
   switch(type){
-    case 'CreateEvent':
+    case 'CreateEvent': 
     case 'DeleteEvent': {
       const target = payload?.ref;
       const targetType = payload?.ref_type;
-      if (!target || !targetType) {
+      const action = type === 'CreateEvent'? 'created' : 'deleted'; 
+      if (!target) {
+        return <span>{action} the {targetType} </span>;
+      }
+      if (!targetType) {
         return unknown;
       }
-      const action = type === 'CreateEvent'? 'created' : 'deleted';
       return <span>{action} {targetType} <code>{target}</code> in</span>;
     }
     case 'ForkEvent': {


### PR DESCRIPTION
Fixes #23,
Since `ref` is `null` in the dump of repository create event. I added another if condition to handle the case. 