### PR TITLE
fix: turned off image preloading to fix project spotlight mismatch image bug

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -105,7 +105,7 @@ export default function Home({
         <hr className="mt-2" />
 
         <h2>featured project</h2>
-        <ProjectCard project={projects[getRandomProj()]} preload={true} />
+        <ProjectCard project={projects[getRandomProj()]} preload={false} />
         <h2>what we&apos;ve been doing recently...</h2>
         <p>this is a live feed of our {numRepos} repositories</p>
         <div className="card">

--- a/test/pages/__snapshots__/index.test.tsx.snap
+++ b/test/pages/__snapshots__/index.test.tsx.snap
@@ -194,9 +194,7 @@ exports[`Home page matches snapshot 1`] = `
                   alt="buffer buffet landing splash"
                   data-nimg="responsive"
                   decoding="async"
-                  sizes="100vw"
-                  src="/_next/image?url=%2Fprojects%2Fbuffer-buffet.png&w=3840&q=75"
-                  srcset="/_next/image?url=%2Fprojects%2Fbuffer-buffet.png&w=640&q=75 640w, /_next/image?url=%2Fprojects%2Fbuffer-buffet.png&w=750&q=75 750w, /_next/image?url=%2Fprojects%2Fbuffer-buffet.png&w=828&q=75 828w, /_next/image?url=%2Fprojects%2Fbuffer-buffet.png&w=1080&q=75 1080w, /_next/image?url=%2Fprojects%2Fbuffer-buffet.png&w=1200&q=75 1200w, /_next/image?url=%2Fprojects%2Fbuffer-buffet.png&w=1920&q=75 1920w, /_next/image?url=%2Fprojects%2Fbuffer-buffet.png&w=2048&q=75 2048w, /_next/image?url=%2Fprojects%2Fbuffer-buffet.png&w=3840&q=75 3840w"
+                  src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
                   style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
                 />
                 <noscript />


### PR DESCRIPTION
can completely remove `preload` as a chained prop if this is the path that we want to go

can allow `preload` for tests instead of modifying snapshot if that's the path we want to go