### PR TITLE
standardize node version to `16.x`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-14
+lts/gallium


### PR DESCRIPTION
Updates both actions + updates `.nvrmc`. Also changes the required check to be 16 instead of 14 (done in the GitHub UI).