### PR TITLE
turns on strict mode for TSLint, resolves/punts all errors

### DIFF
--- a/components/GitHubEvent.tsx
+++ b/components/GitHubEvent.tsx
@@ -9,8 +9,10 @@ interface GitHubEvent {
   actor: GitHubActor
   repo: GitHubRepo
   created_at: string
-  // TODO(#74): Change payload to GitHubEventPayloadType when types are accurate
+  // TODO(#74): Change payload to GitHubEventPayloadType when types are accurate;
+  // being resolved in https://github.com/uclaacm/opensource/pull/57
   // payload: GitHubEventPayloadType
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   payload: any
 }
 

--- a/pages/api/hello.ts
+++ b/pages/api/hello.ts
@@ -2,7 +2,7 @@
 
 import { NextApiRequest, NextApiResponse } from 'next';
 
-const handler = (req: NextApiRequest, res: NextApiResponse) => {
+const handler = (_: NextApiRequest, res: NextApiResponse): void => {
   res.status(200).json({ name: 'John Doe' });
 };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,5 @@
 import { Octokit } from '@octokit/core';
-import { GetStaticProps } from 'next';
+import { GetStaticProps, InferGetStaticPropsType } from 'next';
 import { NextSeo } from 'next-seo';
 import Link from 'next/link';
 import React from 'react';
@@ -10,12 +10,6 @@ import ProjectCard from '../components/ProjectCard';
 
 import projects from '../data/projects';
 
-interface HomeProps {
-  numRepos: number
-  recentEvents: GitHubEvent[],
-  projNumToDisplay: number
-}
-
 function getRandomProj() {
   return Math.floor(Math.random() * projects.length);
 }
@@ -24,7 +18,7 @@ export default function Home({
   numRepos,
   recentEvents,
   projNumToDisplay,
-}: HomeProps): JSX.Element {
+}: InferGetStaticPropsType<typeof getStaticProps>): JSX.Element {
   return (
     <Layout>
       <div className="container">
@@ -112,7 +106,7 @@ export default function Home({
         <p>this is a live feed of our {numRepos} repositories</p>
         <div className="card">
           <div className="card-body">
-            {recentEvents.map((event) => (
+            {recentEvents.map((event: GitHubEvent) => (
               <GitHubEvent {...event} key={event.id} />
             ))}
             <p>
@@ -129,7 +123,7 @@ export default function Home({
   );
 }
 
-export const getStaticProps: GetStaticProps<HomeProps> = async () => {
+export const getStaticProps: GetStaticProps = async () => {
   // TODO(mattxwang): change the auth scope and get members, etc.
   // see: https://docs.github.com/en/rest/reference/orgs
   const octokit = new Octokit();

--- a/test/components/GitHubEventAction.test.tsx
+++ b/test/components/GitHubEventAction.test.tsx
@@ -84,10 +84,11 @@ describe('GitHub Event Action', () => {
       const {container} = render(<GitHubEventAction payload={data.payload} type={data.type} />, {});
 
       const element = container.querySelector('span');
-      expect(element.textContent).toBe(expectedOutput);
+      expect(element?.textContent).toBe(expectedOutput);
 
       if (expectedHref) {
-        expect(element.querySelector('a').href).toBe(expectedHref);
+        const linkElement = element?.querySelector('a');
+        expect(linkElement?.href).toBe(expectedHref);
       }
     });
   });

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -1,23 +1,10 @@
 import { render } from '@testing-library/react';
-// import { ThemeProvider } from "my-ui-lib"
-// import { TranslationProvider } from "my-i18n-lib"
-// import defaultStrings from "i18n/en-x-default"
-
-const Providers = ({ children }) => {
-  return children;
-  // return (
-  //   <ThemeProvider theme="light">
-  //     <TranslationProvider messages={defaultStrings}>
-  //       {children}
-  //     </TranslationProvider>
-  //   </ThemeProvider>
-  // )
-};
+import React from 'react';
 
 // boilerplate code
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const customRender = (ui: JSX.Element, options = {}): any =>
-  render(ui, { wrapper: Providers, ...options });
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const customRender = (ui: React.ReactElement, options = {}) =>
+  render(ui, { wrapper: ({children}) => children, ...options });
 
 // re-export everything
 export * from '@testing-library/react';

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -14,7 +14,9 @@ const Providers = ({ children }) => {
   // )
 };
 
-const customRender = (ui, options = {}) =>
+// boilerplate code
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const customRender = (ui: JSX.Element, options = {}): any =>
   render(ui, { wrapper: Providers, ...options });
 
 // re-export everything

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Punts the GitHub Action typing since #57 will likely resolve it, and resolves/punts boilerplate code errors.

Changes getStaticProps typing via [this SO post's instructions](https://stackoverflow.com/questions/65078245/how-to-make-next-js-getstaticprops-work-with-typescript).

To resolve testing wrapper props, looks at [this SO Post](https://stackoverflow.com/questions/68460887/whats-the-proper-typing-for-a-react-testing-library-wrapper-in-typescript) - basically, using type inference.

Adds optional chaining for tests.