### PR TITLE
Update next version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@octokit/types": "^6.34.0",
     "@octokit/webhooks-types": "^5.4.0",
     "moment": "^2.29.3",
-    "next": "^11.1.3",
+    "next": "^14.0.4",
     "next-seo": "^5.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.1"


### PR DESCRIPTION
Next.js's static revalidation is not auto-updating. It only updates after being redeployed. Trying to fix by updating next version

Maybe problem is related to this?? https://github.com/vercel/next.js/issues/56231