### PR TITLE
fix: handle missing case

### DIFF
--- a/util/projectRequest.ts
+++ b/util/projectRequest.ts
@@ -133,6 +133,7 @@ function topicToImg(topic: string): ImageInfo | false {
         alt: 'ACM AI Logo',
       };
     case ACMCommitteeTopics.CYBER:
+    case 'cyber':
       return {
         image: '/committee-logos/cyber-logo.png',
         alt: 'ACM Cyber Logo',
@@ -184,6 +185,7 @@ export function getImageFromRepo(repo: GitHubRepo): ImageInfo {
 }
 
 function getACMImageFromTopics(topics: string[] | undefined): ImageInfo {
+  // console.log(topics)
   if (topics) {
     for (const topic of topics) {
       const committeeImg = topicToImg(topic);


### PR DESCRIPTION
Fixes #151 

- The topic for the `acmcyber.com` project was named `cyber` not `acm-cyber`, which didn't not match any of the cases in the switch statement. 
- Another solution to this problem can be to fix the topics at the database level. Changing it to `acm-cyber` instead of just `cyber`. But I don't think I have the necessary access to do that.

So I've added a case to handle it. This is how it looks like now:
![image](https://github.com/user-attachments/assets/39bf8942-5f73-4bcd-a944-04df126793a4)
