### PR TITLE
Removed dependabot from live feed

### DIFF
--- a/components/GitHubEvent.tsx
+++ b/components/GitHubEvent.tsx
@@ -8,7 +8,8 @@ import { GitHubEvent } from '../util';
 function GitHubEventComponent(props: GitHubEvent): JSX.Element {
   const { type, actor, repo, payload, created_at } = props;
   const timePassed = moment(created_at).fromNow();
-  const userLink = !actor.login.includes('[bot]') ? <ELink link={`https://github.com/${actor.login}`}>{`@${actor.login}`}</ELink> : actor.login;
+  const userLink = <ELink link={`https://github.com/${actor.login}`}>{`@${actor.login}`}</ELink>;
+
   return (
     <>
       {/* <div className="card" style={{marginTop: "20px"}}> */}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -102,9 +102,17 @@ export default function Home({
         <p>this is a live feed of our {numRepos} repositories</p>
         <div className="card">
           <div className="card-body">
-            {recentEvents.map((event: GitHubEvent) => (
-              <GitHubEventComponent {...event} key={event.id} />
-            ))}
+            {recentEvents
+              // Filter to remove bot accounts (dependabot, etc)
+              .filter(
+                (event: GitHubEvent) =>
+                  !['[bot]'].some((botAccount) =>
+                    event.actor.login.includes(botAccount),
+                  ),
+              )
+              .map((event: GitHubEvent) => (
+                <GitHubEventComponent {...event} key={event.id} />
+              ))}
             <p>
               see more activity{' '}
               <ELink link="https://github.com/uclaacm/">on our org</ELink>!


### PR DESCRIPTION
## Overview
Resolves #112

## Changes
- `pages/index.tsx`
  - Added filter to remove events containing '[bot]' keyword as the author's name before passing each event into `GitHubEventComponent`
- `components/GitHubEvent.tsx`
  - Removed check for bot account when rendering a hyperlink since this will no longer happen

## Possible Changes
- Add other bot accounts to be removed from live feed if necessary by modifying the array within the filter