### PR TITLE
Responsive main page

### DIFF
--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/legacy/image';
-import React from 'react';
+import React, {useState, useEffect } from 'react';
 import ELink from './ELink';
 import { Project, GitHubColors } from '../util/';
 
@@ -123,7 +123,17 @@ function ProjectCard({
   githubColors,
   searchQuery = '',
 }: ProjectCardProps): JSX.Element {
-  if (vertical) {
+
+  // For mobile devices, set project card to be always in `vertical` format
+  const [isVertical, setIsVertical] = useState(vertical);
+  useEffect(() => {
+    const handleResize = () => setIsVertical(vertical || window.innerWidth < 540);
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [vertical]);
+
+  if (isVertical) {
     return (
       <div className="card">
         <ProjectCardImage project={project} preload={preload} />

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -141,9 +141,7 @@ function ProjectCard({
   if (isVertical) {
     return (
       <div className="card">
-        {/* <div className="card-image-container"> */}
         <ProjectCardImage project={project} preload={preload} />
-        {/* </div> */}
         <ProjectCardBody
           searchQuery={searchQuery}
           project={project}
@@ -156,9 +154,7 @@ function ProjectCard({
     <div className="card">
       <div className="row">
         <div className="col-6 centered-content">
-          {/* <div className="card-image-container"> */}
           <ProjectCardImage project={project} preload={preload} />
-          {/* </div> */}
         </div>
         <div className="col-6">
           <ProjectCardBody

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/legacy/image';
-import React, {useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import ELink from './ELink';
 import { Project, GitHubColors } from '../util/';
 
@@ -18,28 +18,34 @@ interface ProjectCardImageProps {
 
 function ProjectCardImage({ project, preload }: ProjectCardImageProps) {
   const { image, alt, link } = project;
-  return link ? (
-    <ELink link={link}>
-      <Image
-        src={image ?? '/logo.png'}
-        alt={alt}
-        width="1000"
-        height="1000"
-        layout="responsive"
-        priority={preload}
-      />
-    </ELink>
-  ) : (
-    <>
-      <Image
-        src={image}
-        alt={alt}
-        width="1000"
-        height="1000"
-        layout="responsive"
-        priority={preload}
-      />
-    </>
+  return (
+    <div className="card-image-container">
+      {link ? (
+        <ELink link={link}>
+          <Image
+            src={image ?? '/logo.png'}
+            alt={alt}
+            width="1000"
+            height="1000"
+            layout="fill"
+            objectFit="contain"
+            priority={preload}
+          />
+        </ELink>
+      ) : (
+        <>
+          <Image
+            src={image}
+            alt={alt}
+            width="1000"
+            height="1000"
+            layout="fill"
+            objectFit="contain"
+            priority={preload}
+          />
+        </>
+      )}
+    </div>
   );
 }
 
@@ -123,7 +129,6 @@ function ProjectCard({
   githubColors,
   searchQuery = '',
 }: ProjectCardProps): JSX.Element {
-
   // For mobile devices, set project card to be always in `vertical` format
   const [isVertical, setIsVertical] = useState(vertical);
   useEffect(() => {
@@ -136,7 +141,9 @@ function ProjectCard({
   if (isVertical) {
     return (
       <div className="card">
+        {/* <div className="card-image-container"> */}
         <ProjectCardImage project={project} preload={preload} />
+        {/* </div> */}
         <ProjectCardBody
           searchQuery={searchQuery}
           project={project}
@@ -148,8 +155,10 @@ function ProjectCard({
   return (
     <div className="card">
       <div className="row">
-        <div className="col-6">
+        <div className="col-6 centered-content">
+          {/* <div className="card-image-container"> */}
           <ProjectCardImage project={project} preload={preload} />
+          {/* </div> */}
         </div>
         <div className="col-6">
           <ProjectCardBody

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -45,8 +45,9 @@ export default function Home({
           maintained by <ELink link="https://uclaacm.com">ACM at UCLA</ELink>,
           the largest computer science community at UCLA
         </p>
+
         <div className="row">
-          <div className="col-6">
+          <div className="col-6 col-mb-12">
             <div className="card">
               <div className="card-body">
                 <Link href="/projects">
@@ -56,7 +57,7 @@ export default function Home({
               </div>
             </div>
           </div>
-          <div className="col-6">
+          <div className="col-6 col-mb-12">
             <div className="card">
               <div className="card-body">
                 <ELink link="https://dev-pathways.netlify.app/">
@@ -68,8 +69,8 @@ export default function Home({
           </div>
         </div>
 
-        <div className="row mt-2">
-          <div className="col-6">
+        <div className="row">
+          <div className="col-6 col-mb-12">
             <div className="card">
               <div className="card-body">
                 <ELink link="https://uclaacm.com/events">
@@ -79,7 +80,7 @@ export default function Home({
               </div>
             </div>
           </div>
-          <div className="col-6">
+          <div className="col-6 col-mb-12">
             <div className="card">
               <div className="card-body">
                 <Link href="/contribute">
@@ -90,7 +91,7 @@ export default function Home({
             </div>
           </div>
         </div>
-        <hr className="mt-2" />
+        <hr />
 
         <h2>featured project</h2>
         <ProjectCard

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -42,6 +42,13 @@ body {
   height: 100%;
 }
 
+.card-image-container {
+  width: 100%;
+  height: 20rem;
+  max-height: 40vh;
+  position: relative;
+}
+
 .assignee-image {
   border-radius: 50%;
   overflow: hidden;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -24,6 +24,14 @@ body {
   margin-top: 2rem;
 }
 
+.row {
+  margin-bottom: 1rem;
+}
+
+.col-mb-12 {
+  margin-bottom: 0.5rem;
+}
+
 .row.same-height-grid {
   row-gap: 2rem;
   overflow-wrap: break-word;


### PR DESCRIPTION
## Overview

Fixes #203 

## Issues
*Fix on left, original issue on right*

1. Unresponsive cards on main page
![main-page-comparison](https://github.com/user-attachments/assets/338f95c1-e37a-4efa-a5d9-f90bb4cbbc8d)

2. Unresponsive featured project on main page
![featured-project-comparison](https://github.com/user-attachments/assets/8bab1ade-23e6-4bb9-94b9-a530b2578a8a)

3. Project image covers entire view on small screens
 ![project-image-comparison](https://github.com/user-attachments/assets/73ac7df4-9cfe-446f-9057-107fb85c2d52)

## Changes

- `pages/index.tsx`
  - Utilize column breakpoints in CSS library to handle responsiveness of "Projects", "Learning", "Events", "Contribute" cards
- `components/ProjectCard.tsx`
  - Add `useEffect` hook to check for window size; for smaller screens, always render project card in `vertical` format
  - Restrict logo image within each project card to be a fraction of view height
- `styles/globals.css`
  - Add necessary styles to support above changes